### PR TITLE
Skip Dependabot runs in README.md example

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.39

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ jobs:
   main:
     name: Coverage
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - name: Setup Golang
         uses: actions/setup-go@v2


### PR DESCRIPTION
As noted here: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and will not have access to any secrets available in the repository.

While in the area, bumped the version of `golangci-lint` in the lint workflow run.