### PR TITLE
Use the initial `GITHUB_TOKEN` pulled from `os.Getenv()`

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,8 @@ func main() {
 }
 
 func createOrUpdateComment(ctx context.Context, title string, details string) {
+	const coverageReportHeaderMarkdown = "### coverage diff"
+
 	auth_token := os.Getenv("GITHUB_TOKEN")
 	if auth_token == "" {
 		fmt.Println("no GITHUB_TOKEN, unable to report back to GitHub pull request.")
@@ -93,7 +95,10 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 	}
 
 	// iterate over existing pull request comments - if existing coverage comment found then update
-	body := fmt.Sprintf("### coverage diff\n%s\n\n```\n%s```\n", title, details)
+	body := fmt.Sprintf("%s\n%s\n\n```\n%s```\n",
+		coverageReportHeaderMarkdown,
+		title, details)
+
 	for _, c := range comments {
 		if c.Body == nil {
 			continue
@@ -104,7 +109,7 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 			return
 		}
 
-		if strings.HasPrefix(*c.Body, "### coverage diff") {
+		if strings.HasPrefix(*c.Body, coverageReportHeaderMarkdown) {
 			// found existing cover comment - update
 			_, _, err = client.Issues.EditComment(ctx, owner, repo, *c.ID, &github.IssueComment{
 				Body: &body,

--- a/main.go
+++ b/main.go
@@ -53,9 +53,9 @@ func main() {
 }
 
 func createOrUpdateComment(ctx context.Context, title string, details string) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		fmt.Println("no GITHUB_TOKEN, not reporting to GitHub.")
+	auth_token := os.Getenv("GITHUB_TOKEN")
+	if auth_token == "" {
+		fmt.Println("no GITHUB_TOKEN, unable to report back to GitHub pull request.")
 		return
 	}
 
@@ -65,9 +65,9 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 		return
 	}
 
-	repoparts := strings.SplitN(ownerAndRepo, "/", 2)
-	owner := repoparts[0]
-	repo := repoparts[1]
+	parts := strings.SplitN(ownerAndRepo, "/", 2)
+	owner := parts[0]
+	repo := parts[1]
 
 	prIdStr := os.Getenv("GITHUB_PULL_REQUEST_ID")
 	if prIdStr == "" {
@@ -77,12 +77,12 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 
 	prID, err := strconv.Atoi(os.Getenv("GITHUB_PULL_REQUEST_ID"))
 	if err != nil {
-		fmt.Println("GITHUB_PULL_REQUEST_ID not a valid number, not reporting to GitHub.")
+		fmt.Println("provided GITHUB_PULL_REQUEST_ID is not a valid number, not reporting to GitHub.")
 		return
 	}
 
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+		&oauth2.Token{AccessToken: auth_token},
 	)
 	tc := oauth2.NewClient(context.Background(), ts)
 
@@ -92,19 +92,20 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 		panic(err)
 	}
 
-	body := "### coverage diff\n" + title + "\n\n```\n" + details + "```\n"
-
+	// iterate over existing pull request comments - if existing coverage comment found then update
+	body := fmt.Sprintf("### coverage diff\n%s\n\n```\n%s```\n", title, details)
 	for _, c := range comments {
 		if c.Body == nil {
 			continue
 		}
 
 		if *c.Body == body {
-			// no change required, lets GTFO.
+			// existing comment body is the same - no change required
 			return
 		}
 
 		if strings.HasPrefix(*c.Body, "### coverage diff") {
+			// found existing cover comment - update
 			_, _, err = client.Issues.EditComment(ctx, owner, repo, *c.ID, &github.IssueComment{
 				Body: &body,
 			})
@@ -115,6 +116,7 @@ func createOrUpdateComment(ctx context.Context, title string, details string) {
 		}
 	}
 
+	// no coverage comment found - create new comment
 	_, _, err = client.Issues.CreateComment(ctx, owner, repo, prID, &github.IssueComment{
 		Body: &body,
 	})


### PR DESCRIPTION
- Small tweak - noted that `os.Getenv("GITHUB_TOKEN")` was pulled, but then not used - with another call to `os.Getenv("GITHUB_TOKEN")`.
- Also added some comments around what's going on here with the create/update PR comment decisions.
- Finally, put the comment header of `### coverage diff` into a `const` - as it's used twice.