### PR TITLE
Table formatting tweaks - tests for report generation output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
-	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
-	golang.org/x/tools v0.1.0
 	google.golang.org/appengine v1.6.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -126,7 +126,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -169,8 +168,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -197,7 +194,6 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897 h1:KrsHThm5nFk34YtATK1LsThyGhGbGe1olrte/HInHvs=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
@@ -216,7 +212,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -242,10 +237,7 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -296,8 +288,6 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-github/v34/github"
 	"golang.org/x/oauth2"
-	"golang.org/x/tools/go/packages"
 )
 
 func main() {
@@ -199,16 +198,7 @@ func getModulePackageName() string {
 }
 
 func getAllPackages(profiles ...*CoverProfile) []string {
-	pkg, err := packages.Load(&packages.Config{Mode: packages.NeedName}, "./...")
-	if err != nil {
-		panic(err)
-	}
-
 	set := map[string]struct{}{}
-	for _, p := range pkg {
-		set[p.PkgPath] = struct{}{}
-	}
-
 	for _, profile := range profiles {
 		for name := range profile.Packages {
 			set[name] = struct{}{}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	// load given base and head `go test` cover profiles from disk
 	base, err := LoadCoverProfile(os.Args[1])
 	if err != nil {
@@ -52,7 +54,7 @@ func main() {
 
 	// generate GitHub pull request message
 	createOrUpdateComment(
-		context.Background(),
+		ctx,
 		summaryMessage(base.Coverage(), head.Coverage()),
 		buf.String())
 }

--- a/main.go
+++ b/main.go
@@ -35,11 +35,11 @@ func main() {
 	buf.WriteString(fmt.Sprintf("%-84s %7s %7s %8s\n", "package name", "before", "after", "delta"))
 
 	// write package lines
-	for _, pkg := range getAllPackages(base, head) {
-		baseCov := base.Packages[pkg].Coverage()
-		headCov := head.Packages[pkg].Coverage()
+	for _, pkgName := range getAllPackages(base, head) {
+		baseCov := base.Packages[pkgName].Coverage()
+		headCov := head.Packages[pkgName].Coverage()
 		buf.WriteString(fmt.Sprintf("%-84s %7s %7s %8s\n",
-			relativePackage(pkg, rootName),
+			relativePackage(rootName, pkgName),
 			coverageDescription(baseCov),
 			coverageDescription(headCov),
 			diffDescription(baseCov, headCov)))
@@ -137,6 +137,13 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	}
 }
 
+func relativePackage(root, pkgName string) string {
+	if strings.HasPrefix(pkgName, root) {
+		return "./" + strings.TrimPrefix(pkgName, root)
+	}
+	return pkgName
+}
+
 func coverageDescription(coverage int) string {
 	if coverage < 0 {
 		return "-"
@@ -168,13 +175,6 @@ func summaryMessage(base, head int) string {
 	}
 
 	return fmt.Sprintf("Coverage increased by %6.1f%%. Keep it up :medal_sports:", float64(head-base)/100)
-}
-
-func relativePackage(pkg, root string) string {
-	if strings.HasPrefix(pkg, root) {
-		return "./" + strings.TrimPrefix(pkg, root)
-	}
-	return pkg
 }
 
 func getModulePackageName() string {

--- a/main.go
+++ b/main.go
@@ -139,8 +139,13 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 
 func relativePackage(root, pkgName string) string {
 	if strings.HasPrefix(pkgName, root) {
-		return "./" + strings.TrimPrefix(pkgName, root)
+		pkgName = strings.TrimPrefix(pkgName, root)
 	}
+
+	if len(pkgName) > 80 {
+		pkgName = pkgName[:80]
+	}
+
 	return pkgName
 }
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 		panic(err)
 	}
 
-	rootName := getModulePackageName()
+	rootPkgName := getModulePackageName() + "/"
 
 	// write report header
 	var buf strings.Builder
@@ -39,7 +39,7 @@ func main() {
 		baseCov := base.Packages[pkgName].Coverage()
 		headCov := head.Packages[pkgName].Coverage()
 		buf.WriteString(fmt.Sprintf("%-84s %7s %7s %8s\n",
-			relativePackage(rootName, pkgName),
+			relativePackage(rootPkgName, pkgName),
 			coverageDescription(baseCov),
 			coverageDescription(headCov),
 			diffDescription(baseCov, headCov)))
@@ -180,13 +180,14 @@ func summaryMessage(base, head int) string {
 func getModulePackageName() string {
 	f, err := os.ReadFile("go.mod")
 	if err != nil {
+		// unable to determine package name
 		return ""
 	}
-	// found it, stop searching
-	return string(modRegex.FindSubmatch(f)[1]) + "/"
-}
 
-var modRegex = regexp.MustCompile(`module ([^\s]*)`)
+	// found it, stop searching
+	modRegex := regexp.MustCompile(`module +([^\s]+)`)
+	return string(modRegex.FindSubmatch(f)[1])
+}
 
 func getAllPackages(profiles ...*CoverProfile) []string {
 	set := map[string]struct{}{}

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func coverageDescription(coverage int) string {
 
 func diffDescription(base, head int) string {
 	if base < 0 && head < 0 {
-		return ""
+		return "n/a"
 	}
 	if base < 0 {
 		return "new"

--- a/main.go
+++ b/main.go
@@ -179,10 +179,10 @@ func summaryMessage(base, head int) string {
 	}
 
 	if base > head {
-		return fmt.Sprintf("Coverage decreased by %6.1f%%. :bell: Shame :bell:", float64(base-head)/100)
+		return fmt.Sprintf("Coverage decreased by %6.2f%%. :bell: Shame :bell:", float64(base-head)/100)
 	}
 
-	return fmt.Sprintf("Coverage increased by %6.1f%%. Keep it up :medal_sports:", float64(head-base)/100)
+	return fmt.Sprintf("Coverage increased by %6.2f%%. Keep it up :medal_sports:", float64(head-base)/100)
 }
 
 func getModulePackageName() string {

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 }
 
 func createOrUpdateComment(ctx context.Context, title, details string) {
-	const coverageReportHeaderMarkdown = "### coverage diff"
+	const coverageReportHeaderMarkdown = "# Golang test coverage diff report"
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
 	if auth_token == "" {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,85 @@ func TestRelativePackage(t *testing.T) {
 	assert.Equal(t,
 		"my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/s",
 		relativePackage(rootPkgName, "github.com/flipgroup/goverdiff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
+}
+
+func TestBuildTable(t *testing.T) {
+	t.Run("empty data set", func(t *testing.T) {
+		base := &CoverProfile{}
+		head := &CoverProfile{}
+
+		assert.Equal(t, strings.TrimLeft(`
+package                                                                            before    after    delta
+-------                                                                            ------    -----    -----
+                                                                          total:        -        -      n/a
+`, "\n"),
+			buildTable("", base, head))
+	})
+
+	t.Run("package data only base", func(t *testing.T) {
+		base := &CoverProfile{
+			Total:   60,
+			Covered: 20,
+			Packages: map[string]*Package{
+				"github.com/flipgroup/goverdiff/my/package": {
+					Total:   8,
+					Covered: 3,
+				},
+			},
+		}
+
+		head := &CoverProfile{
+			Total:   80,
+			Covered: 33,
+		}
+
+		assert.Equal(t, strings.TrimLeft(`
+package                                                                            before    after    delta
+-------                                                                            ------    -----    -----
+my/package                                                                         37.50%        -  deleted
+                                                                          total:   33.33%   41.25%   +7.92%
+`, "\n"),
+			buildTable("github.com/flipgroup/goverdiff", base, head))
+	})
+
+	t.Run("package data both sides", func(t *testing.T) {
+		base := &CoverProfile{
+			Total:   60,
+			Covered: 20,
+			Packages: map[string]*Package{
+				"github.com/flipgroup/goverdiff/my/package": {
+					Total:   8,
+					Covered: 3,
+				},
+				"github.com/flipgroup/goverdiff/apples": {
+					Total:   52,
+					Covered: 17,
+				},
+			},
+		}
+
+		head := &CoverProfile{
+			Total:   80,
+			Covered: 33,
+			Packages: map[string]*Package{
+				"github.com/flipgroup/goverdiff/my/package": {
+					Total:   28,
+					Covered: 16,
+				},
+				"github.com/flipgroup/goverdiff/apples": {
+					Total:   52,
+					Covered: 17,
+				},
+			},
+		}
+
+		assert.Equal(t, strings.TrimLeft(`
+package                                                                            before    after    delta
+-------                                                                            ------    -----    -----
+apples                                                                             32.69%   32.69%   +0.00%
+my/package                                                                         37.50%   57.14%  +19.64%
+                                                                          total:   33.33%   41.25%   +7.92%
+`, "\n"),
+			buildTable("github.com/flipgroup/goverdiff", base, head))
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModulePackageName(t *testing.T) {
+	assert.Equal(t, "github.com/flipgroup/goverdiff", getModulePackageName())
+}

--- a/main_test.go
+++ b/main_test.go
@@ -9,3 +9,19 @@ import (
 func TestModulePackageName(t *testing.T) {
 	assert.Equal(t, "github.com/flipgroup/goverdiff", getModulePackageName())
 }
+
+func TestRelativePackage(t *testing.T) {
+	const rootPkgName = "github.com/flipgroup/goverdiff/"
+
+	assert.Equal(t,
+		"my/cool/package",
+		relativePackage(rootPkgName, "my/cool/package"))
+
+	assert.Equal(t,
+		"my/cool/package",
+		relativePackage(rootPkgName, "github.com/flipgroup/goverdiff/my/cool/package"))
+
+	assert.Equal(t,
+		"my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/s",
+		relativePackage(rootPkgName, "github.com/flipgroup/goverdiff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
+}

--- a/report_test.go
+++ b/report_test.go
@@ -140,9 +140,11 @@ func TestMessaging(t *testing.T) {
 
 	t.Run("summaryMessage()", func(t *testing.T) {
 		assert.Equal(t, "Coverage unchanged.", summaryMessage(100, 100))
-		assert.Equal(t, "Coverage decreased by    1.1%. :bell: Shame :bell:", summaryMessage(205, 100))         // 2.05% -> 1.00%
-		assert.Equal(t, "Coverage decreased by   99.0%. :bell: Shame :bell:", summaryMessage(10000, 100))       // 100.00% -> 1.00%
-		assert.Equal(t, "Coverage increased by    1.1%. Keep it up :medal_sports:", summaryMessage(100, 205))   // 1.00% -> 2.05%
-		assert.Equal(t, "Coverage increased by   99.0%. Keep it up :medal_sports:", summaryMessage(100, 10000)) // 1.00% -> 100.00%
+		assert.Equal(t, "Coverage decreased by   1.05%. :bell: Shame :bell:", summaryMessage(205, 100))         // 2.05% -> 1.00%
+		assert.Equal(t, "Coverage decreased by  99.00%. :bell: Shame :bell:", summaryMessage(10000, 100))       // 100.00% -> 1.00%
+		assert.Equal(t, "Coverage decreased by  98.98%. :bell: Shame :bell:", summaryMessage(10000, 102))       // 100.00% -> 1.02%
+		assert.Equal(t, "Coverage increased by   1.05%. Keep it up :medal_sports:", summaryMessage(100, 205))   // 1.00% -> 2.05%
+		assert.Equal(t, "Coverage increased by  99.00%. Keep it up :medal_sports:", summaryMessage(100, 10000)) // 1.00% -> 100.00%
+		assert.Equal(t, "Coverage increased by   4.25%. Keep it up :medal_sports:", summaryMessage(100, 525))   // 1.00% -> 5.25%
 	})
 }

--- a/report_test.go
+++ b/report_test.go
@@ -128,7 +128,7 @@ func TestMessaging(t *testing.T) {
 	})
 
 	t.Run("diffDescription()", func(t *testing.T) {
-		assert.Equal(t, "", diffDescription(-1, -1))
+		assert.Equal(t, "n/a", diffDescription(-1, -1))
 		assert.Equal(t, "new", diffDescription(-1, 100))
 		assert.Equal(t, "deleted", diffDescription(100, -1))
 


### PR DESCRIPTION
After #11 - with percentages to now two decimal places - the report table needed a little more room to breathe.

- Move the report table generation into `buildTable()` - making tests easer.
- Added tests for `buildTable()` with some basic golden tests.
- `relativePackage()` will now chomp stupidly long package names to avoid breaking the table layout
- Tests for `relativePackage()`
- `diffDescription()` returns `n/a` if no diff to calculate for a table row cell.
- Test for `getModulePackageName()`
- Removed the need to work out the module name of self (`packages.Load(()`) - this is all driven by the coverage report file data.