### PR TITLE
Small tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{go.mod,go.sum,*.go}]
+indent_style = tab
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### goverdiff
+# goverdiff
 
 [![Test](https://github.com/flipgroup/goverdiff/actions/workflows/test.yml/badge.svg)](https://github.com/flipgroup/goverdiff/actions/workflows/test.yml)
 
@@ -67,4 +67,4 @@ jobs:
             goverdiff base.profile head.profile
 ```
 
-**Note:** This only works for a `pull_request` workflow event type. A push doesn't provide a `base.ref` to check against.
+**Note:** This only works for a `pull_request` workflow event type. A `push` event type doesn't provide a `base.ref` to check against.

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 		panic(err)
 	}
 
-	// generate GitHub pull request message
+	// generate and publish GitHub pull request message
 	createOrUpdateComment(
 		ctx,
 		summaryMessage(base.Coverage(), head.Coverage()),
@@ -179,10 +179,10 @@ func summaryMessage(base, head int) string {
 	}
 
 	if base > head {
-		return fmt.Sprintf("Coverage decreased by %6.2f%%. :bell: Shame :bell:", float64(base-head)/100)
+		return fmt.Sprintf("Coverage decreased by `%.2f%%`. :bell: Shame :bell:", float64(base-head)/100)
 	}
 
-	return fmt.Sprintf("Coverage increased by %6.2f%%. Keep it up :medal_sports:", float64(head-base)/100)
+	return fmt.Sprintf("Coverage increased by `%.2f%%`. :medal_sports: Keep it up :medal_sports:", float64(head-base)/100)
 }
 
 func getModulePackageName() string {

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 		return
 	}
 
-	prID, err := strconv.Atoi(os.Getenv("GITHUB_PULL_REQUEST_ID"))
+	prID, err := strconv.Atoi(prIdStr)
 	if err != nil {
 		fmt.Println("provided GITHUB_PULL_REQUEST_ID is not a valid number, not reporting to GitHub.")
 		return

--- a/report_test.go
+++ b/report_test.go
@@ -140,11 +140,11 @@ func TestMessaging(t *testing.T) {
 
 	t.Run("summaryMessage()", func(t *testing.T) {
 		assert.Equal(t, "Coverage unchanged.", summaryMessage(100, 100))
-		assert.Equal(t, "Coverage decreased by   1.05%. :bell: Shame :bell:", summaryMessage(205, 100))         // 2.05% -> 1.00%
-		assert.Equal(t, "Coverage decreased by  99.00%. :bell: Shame :bell:", summaryMessage(10000, 100))       // 100.00% -> 1.00%
-		assert.Equal(t, "Coverage decreased by  98.98%. :bell: Shame :bell:", summaryMessage(10000, 102))       // 100.00% -> 1.02%
-		assert.Equal(t, "Coverage increased by   1.05%. Keep it up :medal_sports:", summaryMessage(100, 205))   // 1.00% -> 2.05%
-		assert.Equal(t, "Coverage increased by  99.00%. Keep it up :medal_sports:", summaryMessage(100, 10000)) // 1.00% -> 100.00%
-		assert.Equal(t, "Coverage increased by   4.25%. Keep it up :medal_sports:", summaryMessage(100, 525))   // 1.00% -> 5.25%
+		assert.Equal(t, "Coverage decreased by `1.05%`. :bell: Shame :bell:", summaryMessage(205, 100))                         // 2.05% -> 1.00%
+		assert.Equal(t, "Coverage decreased by `99.00%`. :bell: Shame :bell:", summaryMessage(10000, 100))                      // 100.00% -> 1.00%
+		assert.Equal(t, "Coverage decreased by `98.98%`. :bell: Shame :bell:", summaryMessage(10000, 102))                      // 100.00% -> 1.02%
+		assert.Equal(t, "Coverage increased by `1.05%`. :medal_sports: Keep it up :medal_sports:", summaryMessage(100, 205))    // 1.00% -> 2.05%
+		assert.Equal(t, "Coverage increased by `99.00%`. :medal_sports: Keep it up :medal_sports:", summaryMessage(100, 10000)) // 1.00% -> 100.00%
+		assert.Equal(t, "Coverage increased by `4.25%`. :medal_sports: Keep it up :medal_sports:", summaryMessage(100, 525))    // 1.00% -> 5.25%
 	})
 }


### PR DESCRIPTION
- Added `.editorconfig`
- Small `README.md` tweaks
- Removed repeated use of `os.Getenv("GITHUB_PULL_REQUEST_ID")`
- Put summary percentage rise/fall coverage value into `code block` to help it stand out and no need to left pad.
- More `:medal_sports:` for being a good Golang tester 😄 