### PR TITLE
Rename text when package removed from `deleted` to `gone`

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func diffDescription(base, head int) string {
 		return "new"
 	}
 	if head < 0 {
-		return "deleted"
+		return "gone"
 	}
 
 	return fmt.Sprintf("%+6.2f%%", float64(head-base)/100)

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ package                                                                         
 		assert.Equal(t, strings.TrimLeft(`
 package                                                                            before    after    delta
 -------                                                                            ------    -----    -----
-my/package                                                                         37.50%        -  deleted
+my/package                                                                         37.50%        -     gone
                                                                           total:   33.33%   41.25%   +7.92%
 `, "\n"),
 			buildTable("github.com/flipgroup/goverdiff", base, head))

--- a/report_test.go
+++ b/report_test.go
@@ -130,7 +130,7 @@ func TestMessaging(t *testing.T) {
 	t.Run("diffDescription()", func(t *testing.T) {
 		assert.Equal(t, "n/a", diffDescription(-1, -1))
 		assert.Equal(t, "new", diffDescription(-1, 100))
-		assert.Equal(t, "deleted", diffDescription(100, -1))
+		assert.Equal(t, "gone", diffDescription(100, -1))
 
 		assert.Equal(t, " +0.05%", diffDescription(100, 105))
 		assert.Equal(t, " -0.05%", diffDescription(105, 100))


### PR DESCRIPTION
When a Golang package is removed - currently line is listed with the message `deleted. 

Feel it's better using the text `gone`.