### PR TITLE
Bump `golangci-lint` version - add in `errname` linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41.1
+          version: v1.42.0
       - name: Test
         run: go test -count=1 -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
 
 linters:
   enable:
+    - errname
     - exportloopref
     - goconst
     - godot
@@ -12,7 +13,8 @@ linters:
 
 linters-settings:
   errcheck:
-    ignore: net/http:Write
+    exclude-functions:
+      - (net/http.ResponseWriter).Write
   goconst:
     min-len: 2
     min-occurrences: 2


### PR DESCRIPTION
As per title.

Also swapped `errcheck.ignore` for the superior `errcheck.exclude-functions` syntax in `.golangci.yml`.