### PR TITLE
Update `cover.example.yml` example - use branch name `github.ref` as concurrency key

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -1,7 +1,7 @@
 name: Coverage report
 concurrency:
   cancel-in-progress: true
-  group: cover-pr-${{ github.event.number }}
+  group: cover-${{ github.ref }}
 
 on:
   pull_request:


### PR DESCRIPTION
Noted that now the example workflow is set to run on both pull requests and pushes to `main` - using the pull request number (`github.event.number`) isn't the best suffix for the `concurrency:` key.

Replacing with `github.ref` - which will be:

- `cover-refs/heads/main` for the `main` branch `push` (or PR merge to `main`)
- `cover-refs/pull/PR_NUMBER/merge` for a pull request branch
