### PR TITLE
feat: link support and dry-run mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func getAllPackages(profiles ...*CoverProfile) []string {
 }
 
 func renderLinkTemplate(tmpl, text string, rep *strings.Replacer) string {
-	if tmpl == "" {
+	if tmpl == "" || text == "-" {
 		return text
 	}
 	return fmt.Sprintf("[%s](%s)", text, rep.Replace(tmpl))

--- a/main.go
+++ b/main.go
@@ -83,13 +83,13 @@ func main() {
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {
-	const tableRowSprintf = "%-80s %8s %8s %8s\n"
+	const tableRowSprintf = "|%-80s|%8s|%8s|%8s|\n"
 	rootPkgName += "/"
 
 	// write report header
 	var buf strings.Builder
-	buf.WriteString(fmt.Sprintf(tableRowSprintf, "package", "before", "after", "delta"))
-	buf.WriteString(fmt.Sprintf(tableRowSprintf, "-------", "------", "-----", "-----"))
+	buf.WriteString(fmt.Sprintf(tableRowSprintf, "|package|", "|before|", "|after|", "|delta|"))
+	buf.WriteString(fmt.Sprintf(tableRowSprintf, "|-------|", "|------|", "|-----|", "|-----|"))
 
 	// write package lines
 	for _, pkgName := range getAllPackages(base, head) {
@@ -105,7 +105,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 	}
 
 	// write totals
-	buf.WriteString(fmt.Sprintf("%80s %8s %8s %8s\n",
+	buf.WriteString(fmt.Sprintf("|%80s|%8s|%8s|%8s|\n",
 		"total:",
 		coverageDescription(base.Coverage()),
 		coverageDescription(head.Coverage()),

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	}
 
 	// iterate over existing pull request comments - if existing coverage comment found then update
-	body := fmt.Sprintf("%s\n%s\n\n```\n%s```\n",
+	body := fmt.Sprintf("%s\n%s\n\n\n%s\n",
 		coverageReportHeaderMarkdown,
 		title, details)
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,16 +14,46 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var (
+	baseCovLinkTemple = flag.String("link-template.base", "", "template used to generate links to base commit coverage profiles. See LINK TEMPLATES")
+	headCovLinkTemple = flag.String("link-template.head", "", "template used to generate links to head commit coverage profiles. See LINK TEMPLATES")
+)
+
+func init() {
+	flag.Usage = func() {
+		out := flag.CommandLine.Output()
+		fmt.Fprintf(out, "Usage: %s [OPTIONS] <base-profile> <head-profile>\n", os.Args[0])
+
+		fmt.Fprintln(out, "\nOPTIONS")
+		flag.PrintDefaults()
+
+		fmt.Fprintln(out, "\nLINK TEMPLATES")
+		fmt.Fprintln(out, "In the comment posted to Github PR can optionally include links to")
+		fmt.Fprintln(out, "the html version of the cover profile with color coded lines. In")
+		fmt.Fprintln(out, "order to generate these links pass two links templates. The")
+		fmt.Fprintln(out, "following tokens will be replaced in the template:")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "\t%p -> the current go package name")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Example")
+		fmt.Fprintln(out, "$ goverdiff \\")
+		fmt.Fprintln(out, "\t-link-template.base 'https://ci.acme.com/coverprofiles/before/%p/coverage.html' \\")
+		fmt.Fprintln(out, "\t-link-template.head 'https://ci.acme.com/coverprofiles/after/%p/coverage.html' \\")
+		fmt.Fprintln(out, "\t base/coverage.out head/coverage.out")
+	}
+
+}
 func main() {
 	ctx := context.Background()
+	flag.Parse()
 
 	// load given base and head `go test` cover profiles from disk
-	base, err := LoadCoverProfile(os.Args[1])
+	base, err := LoadCoverProfile(flag.Arg(0))
 	if err != nil {
 		panic(err)
 	}
 
-	head, err := LoadCoverProfile(os.Args[2])
+	head, err := LoadCoverProfile(flag.Arg(1))
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -88,8 +88,8 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 
 	// write report header
 	var buf strings.Builder
-	buf.WriteString(fmt.Sprintf(tableRowSprintf, "|package|", "|before|", "|after|", "|delta|"))
-	buf.WriteString(fmt.Sprintf(tableRowSprintf, "|-------|", "|------|", "|-----|", "|-----|"))
+	buf.WriteString(fmt.Sprintf(tableRowSprintf, "package", "before", "after", "delta"))
+	buf.WriteString(fmt.Sprintf(tableRowSprintf, "-------", "------", "-----", "-----"))
 
 	// write package lines
 	for _, pkgName := range getAllPackages(base, head) {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 var (
 	baseCovLinkTemplate = flag.String("link-template.base", "", "template used to generate links to base commit coverage profiles. See LINK TEMPLATES")
 	headCovLinkTemplate = flag.String("link-template.head", "", "template used to generate links to head commit coverage profiles. See LINK TEMPLATES")
+
+	dryrun = flag.Bool("dry-run", false, "skip posting comment to Github, printing to stdout instead")
 )
 
 func init() {
@@ -69,10 +71,15 @@ func main() {
 	}
 
 	// generate and publish GitHub pull request message
-	createOrUpdateComment(
-		ctx,
-		summaryMessage(base.Coverage(), head.Coverage()),
-		buildTable(getModulePackageName(), base, head))
+	sum := summaryMessage(base.Coverage(), head.Coverage())
+	tab := buildTable(getModulePackageName(), base, head)
+
+	if *dryrun {
+		fmt.Println(sum)
+		fmt.Println(tab)
+	} else {
+		createOrUpdateComment(ctx, sum, tab)
+	}
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {

--- a/main_test.go
+++ b/main_test.go
@@ -106,4 +106,47 @@ my/package                                                                      
 `, "\n"),
 			buildTable("github.com/flipgroup/goverdiff", base, head))
 	})
+
+	t.Run("render link template", func(t *testing.T) {
+
+	})
+}
+
+func TestRenderLinkTemplate(t *testing.T) {
+	type kase struct {
+		name     string
+		tmpl     string
+		text     string
+		expected string
+	}
+	ks := []kase{
+		{
+			name:     "no template specified",
+			tmpl:     "",
+			text:     "55%",
+			expected: "55%",
+		},
+		{
+			name:     "template specified with replace token",
+			tmpl:     "https://ci.acme.com/coverprofiles/before/%[p]/coverage.html",
+			text:     "55%",
+			expected: "[55%](https://ci.acme.com/coverprofiles/before/github.com/flipgroup/goverdiff/coverage.html)",
+		},
+		{
+			name:     "template specified without replace token",
+			tmpl:     "https://ci.acme.com/coverprofiles/before/coverage.html",
+			text:     "55%",
+			expected: "[55%](https://ci.acme.com/coverprofiles/before/coverage.html)",
+		},
+	}
+
+	rep := strings.NewReplacer("%[p]", "github.com/flipgroup/goverdiff")
+	for _, k := range ks {
+		t.Run(k.name, func(t *testing.T) {
+			actual := renderLinkTemplate(k.tmpl, k.text, rep)
+			if actual != k.expected {
+				t.Errorf("expected: %s, got %s", k.expected, actual)
+			}
+		})
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -138,6 +138,12 @@ func TestRenderLinkTemplate(t *testing.T) {
 			text:     "55%",
 			expected: "[55%](https://ci.acme.com/coverprofiles/before/coverage.html)",
 		},
+		{
+			name:     "template specified without text",
+			tmpl:     "https://ci.acme.com/coverprofiles/before/coverage.html",
+			text:     "-",
+			expected: "-",
+		},
 	}
 
 	rep := strings.NewReplacer("%[p]", "github.com/flipgroup/goverdiff")

--- a/main_test.go
+++ b/main_test.go
@@ -33,9 +33,9 @@ func TestBuildTable(t *testing.T) {
 		head := &CoverProfile{}
 
 		assert.Equal(t, strings.TrimLeft(`
-package                                                                            before    after    delta
--------                                                                            ------    -----    -----
-                                                                          total:        -        -      n/a
+|package                                                                         |  before|   after|   delta|
+|-------                                                                         |  ------|   -----|   -----|
+|                                                                          total:|       -|       -|     n/a|
 `, "\n"),
 			buildTable("", base, head))
 	})
@@ -58,10 +58,10 @@ package                                                                         
 		}
 
 		assert.Equal(t, strings.TrimLeft(`
-package                                                                            before    after    delta
--------                                                                            ------    -----    -----
-my/package                                                                         37.50%        -     gone
-                                                                          total:   33.33%   41.25%   +7.92%
+|package                                                                         |  before|   after|   delta|
+|-------                                                                         |  ------|   -----|   -----|
+|my/package                                                                      |  37.50%|       -|    gone|
+|                                                                          total:|  33.33%|  41.25%|  +7.92%|
 `, "\n"),
 			buildTable("github.com/flipgroup/goverdiff", base, head))
 	})
@@ -98,17 +98,13 @@ my/package                                                                      
 		}
 
 		assert.Equal(t, strings.TrimLeft(`
-package                                                                            before    after    delta
--------                                                                            ------    -----    -----
-apples                                                                             32.69%   32.69%   +0.00%
-my/package                                                                         37.50%   57.14%  +19.64%
-                                                                          total:   33.33%   41.25%   +7.92%
+|package                                                                         |  before|   after|   delta|
+|-------                                                                         |  ------|   -----|   -----|
+|apples                                                                          |  32.69%|  32.69%|  +0.00%|
+|my/package                                                                      |  37.50%|  57.14%| +19.64%|
+|                                                                          total:|  33.33%|  41.25%|  +7.92%|
 `, "\n"),
 			buildTable("github.com/flipgroup/goverdiff", base, head))
-	})
-
-	t.Run("render link template", func(t *testing.T) {
-
 	})
 }
 


### PR DESCRIPTION
This PR introduces couple of mostly* backwards compatible changes:

- goverdiff can now optionally make the per-package percentage numbers a hyperlink by specifying that `-link-template.base` and `-link-template.head` arguments.
- `--dry-run` mode to print out the Github comment to stdout instead of actually posting it to Github
- use markdown tables instead of a code-block to present per-package before/after coverage percentages so that links can be rendered.

\[\*\] switching from using codeblocks -> markdown tables for presentation is the only change that sort-of not backwards compatible. Example: 
<img width="470" alt="image" src="https://user-images.githubusercontent.com/1622/158135561-e8fb58f0-3e44-4a4a-b4a7-080dbb05a66b.png">
