### PR TITLE
Bump `actions/cache@v3` - smarter cover profile hashing

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "::set-output name=value::${{ hashFiles('**/*.go') }}"
       - name: Cache base cover profile
         id: cache-base
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: cover-${{ steps.hash-base.outputs.value }}.profile
           key: cover-profile-${{ steps.hash-base.outputs.value }}
@@ -62,7 +62,7 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.hash-base.outputs.value != steps.hash-head.outputs.value
         id: cache-head
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: cover-${{ steps.hash-head.outputs.value }}.profile
           key: cover-profile-${{ steps.hash-head.outputs.value }}
@@ -89,7 +89,7 @@ jobs:
           echo "::set-output name=sha1::$sha1"
       - name: Cache goverdiff
         id: cache-goverdiff
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/bin/goverdiff
           key: ${{ runner.os }}-cover-goverdiff-sha1-${{ steps.goverdiff-main.outputs.sha1 }}

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -32,7 +32,7 @@ jobs:
           version: ~1.17
       - name: Generate Golang source hash base
         id: hash-base
-        run: echo "::set-output name=value::${{ hashFiles('**/*.go') }}"
+        run: echo "::set-output name=value::${{ hashFiles('**/*.go','!vendor/**') }}"
       - name: Cache base cover profile
         id: cache-base
         uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
       - name: Generate Golang source hash head
         if: github.event_name == 'pull_request'
         id: hash-head
-        run: echo "::set-output name=value::${{ hashFiles('**/*.go') }}"
+        run: echo "::set-output name=value::${{ hashFiles('**/*.go','!vendor/**') }}"
       - name: Cache head cover profile
         if: |
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
- Bump: https://github.com/actions/cache/releases/tag/v3.0.0
- No longer include Golang files under `vendor/` when hashing for cover profile (speedup).
  - This also improves the hash generated for base/head - making it more stable, since a `go mod vendor` operation alone within a commit/PR will no longer change the "hash" and allow the last cached profile to continue to be used.