### PR TITLE
Rename project repository name -> `golang-cover-diff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# goverdiff
+# Golang coverage difference reporter
 
-[![Test](https://github.com/flipgroup/goverdiff/actions/workflows/test.yml/badge.svg)](https://github.com/flipgroup/goverdiff/actions/workflows/test.yml)
+[![Test](https://github.com/flipgroup/golang-cover-diff/actions/workflows/test.yml/badge.svg)](https://github.com/flipgroup/golang-cover-diff/actions/workflows/test.yml)
 
-This tool will compare two cover profiles produced by `go test` and reports deltas back into a GitHub pull request.
+This tool - designed for use within a GitHub Actions workflow, will compare `go test` produced cover profiles and report coverage deltas back into a GitHub pull request.
 
-See [`cover.example.yml`](cover.example.yml) for an example coverage workflow template.
+See [`cover.example.yml`](cover.example.yml) for an example coverage GitHub Actions workflow template.

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Golang with cache
         uses: flipgroup/action-golang-with-cache@main
         with:
-          version: ~1.17
+          version-file: go.mod
       - name: Generate Golang source hash base
         id: hash-base
         run: echo "::set-output name=value::${{ hashFiles('**/*.go','!vendor/**') }}"

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-
       # required bootstrap steps (e.g. Docker package registry login, additional packages)
 
       - name: Checkout source
@@ -78,30 +77,30 @@ jobs:
         # >   GOFLAGS: -cover -coverprofile=cover-${{ steps.hash-head.outputs.value }}.profile
         # > run: make test
 
-      - name: Fetch goverdiff @main SHA-1
-        id: goverdiff-main
+      - name: Fetch golang-cover-diff @main SHA-1
+        id: golang-cover-diff-main
         run: |
           sha1=$(curl \
             --header "Accept: application/vnd.github.v3+json" \
             --silent \
-              https://api.github.com/repos/flipgroup/goverdiff/branches/main | \
+              https://api.github.com/repos/flipgroup/golang-cover-diff/branches/main | \
                 jq --raw-output ".commit.sha")
           echo "::set-output name=sha1::$sha1"
-      - name: Cache goverdiff
-        id: cache-goverdiff
+      - name: Cache golang-cover-diff
+        id: cache-golang-cover-diff
         uses: actions/cache@v3
         with:
-          path: ~/go/bin/goverdiff
-          key: ${{ runner.os }}-cover-goverdiff-sha1-${{ steps.goverdiff-main.outputs.sha1 }}
-      - name: Install goverdiff
-        if: steps.cache-goverdiff.outputs.cache-hit != 'true'
-        run: go install github.com/flipgroup/goverdiff@main
-      - name: Run goverdiff
+          path: ~/go/bin/golang-cover-diff
+          key: ${{ runner.os }}-golang-cover-diff-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}
+      - name: Install golang-cover-diff
+        if: steps.cache-golang-cover-diff.outputs.cache-hit != 'true'
+        run: go install github.com/flipgroup/golang-cover-diff@main
+      - name: Run golang-cover-diff
         if: github.event_name == 'pull_request'
         env:
           GITHUB_PULL_REQUEST_ID: ${{ github.event.number }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          goverdiff \
+          golang-cover-diff \
             cover-${{ steps.hash-base.outputs.value }}.profile \
             cover-${{ steps.hash-head.outputs.value }}.profile

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/flipgroup/golang-cover-diff
 go 1.17
 
 require (
-	github.com/google/go-github/v38 v38.1.0
+	github.com/google/go-github/v45 v45.2.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 )
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.17
 
 require (
 	github.com/google/go-github/v38 v38.1.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -17,5 +17,5 @@ require (
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/flipgroup/goverdiff
+module github.com/flipgroup/golang-cover-diff
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,9 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -121,9 +122,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -377,8 +380,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -87,11 +87,10 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v38 v38.1.0 h1:C6h1FkaITcBFK7gAmq4eFzt6gbhEhk7L5z6R3Uva+po=
-github.com/google/go-github/v38 v38.1.0/go.mod h1:cStvrz/7nFr0FoENgG6GLbp53WaelXucT+BBz/3VKx4=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
+github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -140,8 +139,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -243,6 +242,7 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -295,7 +295,6 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 }
 
 func createOrUpdateComment(ctx context.Context, title, details string) {
-	const coverageReportHeaderMarkdown = "# Golang test coverage diff report"
+	const coverageReportHeaderMarkdown = "<!-- info:golang-cover-diff -->\n# Golang test coverage difference report"
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
 	if auth_token == "" {

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v38/github"
+	"github.com/google/go-github/v45/github"
 	"golang.org/x/oauth2"
 )
 

--- a/main.go
+++ b/main.go
@@ -35,13 +35,13 @@ func main() {
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {
-	const tableRowSprintf = "%-80s %8s %8s %8s\n"
+	const tableRowSprintf = "%-80s  %7s  %7s  %7s\n"
 	rootPkgName += "/"
 
 	// write report header
 	var buf strings.Builder
 	buf.WriteString(fmt.Sprintf(tableRowSprintf, "package", "before", "after", "delta"))
-	buf.WriteString(fmt.Sprintf(tableRowSprintf, "-------", "------", "-----", "-----"))
+	buf.WriteString(fmt.Sprintf(tableRowSprintf, "-------", "-------", "-------", "-------"))
 
 	// write package lines
 	for _, pkgName := range getAllPackages(base, head) {

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestBuildTable(t *testing.T) {
 
 		assert.Equal(t, strings.TrimLeft(`
 package                                                                            before    after    delta
--------                                                                            ------    -----    -----
+-------                                                                           -------  -------  -------
                                                                           total:        -        -      n/a
 `, "\n"),
 			buildTable("", base, head))
@@ -59,7 +59,7 @@ package                                                                         
 
 		assert.Equal(t, strings.TrimLeft(`
 package                                                                            before    after    delta
--------                                                                            ------    -----    -----
+-------                                                                           -------  -------  -------
 my/package                                                                         37.50%        -     gone
                                                                           total:   33.33%   41.25%   +7.92%
 `, "\n"),
@@ -99,7 +99,7 @@ my/package                                                                      
 
 		assert.Equal(t, strings.TrimLeft(`
 package                                                                            before    after    delta
--------                                                                            ------    -----    -----
+-------                                                                           -------  -------  -------
 apples                                                                             32.69%   32.69%   +0.00%
 my/package                                                                         37.50%   57.14%  +19.64%
                                                                           total:   33.33%   41.25%   +7.92%

--- a/main_test.go
+++ b/main_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestModulePackageName(t *testing.T) {
-	assert.Equal(t, "github.com/flipgroup/goverdiff", getModulePackageName())
+	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", getModulePackageName())
 }
 
 func TestRelativePackage(t *testing.T) {
-	const rootPkgName = "github.com/flipgroup/goverdiff/"
+	const rootPkgName = "github.com/flipgroup/golang-cover-diff/"
 
 	assert.Equal(t,
 		"my/cool/package",
@@ -20,11 +20,11 @@ func TestRelativePackage(t *testing.T) {
 
 	assert.Equal(t,
 		"my/cool/package",
-		relativePackage(rootPkgName, "github.com/flipgroup/goverdiff/my/cool/package"))
+		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package"))
 
 	assert.Equal(t,
 		"my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/s",
-		relativePackage(rootPkgName, "github.com/flipgroup/goverdiff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
+		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
 }
 
 func TestBuildTable(t *testing.T) {
@@ -45,7 +45,7 @@ package                                                                         
 			Total:   60,
 			Covered: 20,
 			Packages: map[string]*Package{
-				"github.com/flipgroup/goverdiff/my/package": {
+				"github.com/flipgroup/golang-cover-diff/my/package": {
 					Total:   8,
 					Covered: 3,
 				},
@@ -63,7 +63,7 @@ package                                                                         
 my/package                                                                         37.50%        -     gone
                                                                           total:   33.33%   41.25%   +7.92%
 `, "\n"),
-			buildTable("github.com/flipgroup/goverdiff", base, head))
+			buildTable("github.com/flipgroup/golang-cover-diff", base, head))
 	})
 
 	t.Run("package data both sides", func(t *testing.T) {
@@ -71,11 +71,11 @@ my/package                                                                      
 			Total:   60,
 			Covered: 20,
 			Packages: map[string]*Package{
-				"github.com/flipgroup/goverdiff/my/package": {
+				"github.com/flipgroup/golang-cover-diff/my/package": {
 					Total:   8,
 					Covered: 3,
 				},
-				"github.com/flipgroup/goverdiff/apples": {
+				"github.com/flipgroup/golang-cover-diff/apples": {
 					Total:   52,
 					Covered: 17,
 				},
@@ -86,11 +86,11 @@ my/package                                                                      
 			Total:   80,
 			Covered: 33,
 			Packages: map[string]*Package{
-				"github.com/flipgroup/goverdiff/my/package": {
+				"github.com/flipgroup/golang-cover-diff/my/package": {
 					Total:   28,
 					Covered: 16,
 				},
-				"github.com/flipgroup/goverdiff/apples": {
+				"github.com/flipgroup/golang-cover-diff/apples": {
 					Total:   52,
 					Covered: 17,
 				},
@@ -104,6 +104,6 @@ apples                                                                          
 my/package                                                                         37.50%   57.14%  +19.64%
                                                                           total:   33.33%   41.25%   +7.92%
 `, "\n"),
-			buildTable("github.com/flipgroup/goverdiff", base, head))
+			buildTable("github.com/flipgroup/golang-cover-diff", base, head))
 	})
 }


### PR DESCRIPTION
# Introduction

Looking at this project recently, realised that `goverdiff` doesn't really convey what this GitHub workflow helper does - so have proposed a rename to `golang-cover-diff`.

# Changes

- Rename `goverdiff` -> `golang-cover-diff`
- Updated `cover.example.yml` based on rename.
- Added hidden HTML leading `<!-- info:golang-cover-diff -->` marker to comment Markdown - make it easier to find existing comments if format of report in changed in the future.
- Bumped:
  - `github.com/stretchr/testify`
  - `github.com/google/go-github`
- Reformatted (stretched) the report header dashed lines to fully cover `100.00%` (7 chars).
- Updated `README.md` to be a little clearer as to use/purpose.

# Before commit

- Create a _new_ repository of `flipgroup/golang-cover-diff` - setting this branch as it's `main`.
  - Done: https://github.com/flipgroup/golang-cover-diff
- Migrate all projects to implement the new `cover.yml` workflow namings as per `cover.example.yml`.
- Once complete:
  - drop `flipgroup/golang-cover-diff` repo and...
  - rename this repo `flipgroup/goverdiff` -> `flipgroup/golang-cover-diff`.
